### PR TITLE
Fix OSX warnings

### DIFF
--- a/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_publisher_info.hpp
+++ b/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_publisher_info.hpp
@@ -31,8 +31,6 @@
 
 class ConnextPublisherListener;
 
-extern "C"
-{
 struct ConnextStaticPublisherInfo : ConnextCustomEventInfo
 {
   DDS::Publisher * dds_publisher_;
@@ -55,7 +53,6 @@ struct ConnextStaticPublisherInfo : ConnextCustomEventInfo
    */
   DDS::Entity * get_entity() override;
 };
-}  // extern "C"
 
 class ConnextPublisherListener : public DDS::PublisherListener
 {

--- a/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_subscriber_info.hpp
+++ b/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_subscriber_info.hpp
@@ -30,8 +30,6 @@
 
 class ConnextSubscriberListener;
 
-extern "C"
-{
 struct ConnextStaticSubscriberInfo : ConnextCustomEventInfo
 {
   DDS::Subscriber * dds_subscriber_;
@@ -52,7 +50,6 @@ struct ConnextStaticSubscriberInfo : ConnextCustomEventInfo
    */
   DDS::Entity * get_entity() override;
 };
-}  // extern "C"
 
 class ConnextSubscriberListener : public DDS::SubscriberListener
 {

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/connext_static_event_info.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/connext_static_event_info.hpp
@@ -15,9 +15,6 @@
 #ifndef RMW_CONNEXT_SHARED_CPP__CONNEXT_STATIC_EVENT_INFO_HPP_
 #define RMW_CONNEXT_SHARED_CPP__CONNEXT_STATIC_EVENT_INFO_HPP_
 
-#include "ndds/ndds_cpp.h"
-#include "ndds/ndds_namespace_cpp.h"
-
 #include "rmw/ret_types.h"
 
 #include "rmw_connext_shared_cpp/ndds_include.hpp"


### PR DESCRIPTION
Fix OSX compiler warnings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
